### PR TITLE
+Fixed a bug affecting the population of indexInfo for local accounts…

### DIFF
--- a/lib/api/apiKeyring.dart
+++ b/lib/api/apiKeyring.dart
@@ -157,6 +157,7 @@ class ApiKeyring {
         data[e['accountId']] = e;
       });
       keyring.store.updateIndicesMap(Map<String, Map>.from(data));
+      keyring.allAccounts;
     }
   }
 

--- a/lib/storage/keyring.dart
+++ b/lib/storage/keyring.dart
@@ -109,7 +109,7 @@ class KeyringPrivateStore {
         e['address'] = _pubKeyAddressMap[networkSS58][e['pubKey']];
       }
       e['icon'] = _iconsMap[e['pubKey']];
-      e['indexInfo'] = _indicesMap[e['pubKey']];
+      e['indexInfo'] = _indicesMap[e['address']];
     });
     return ls;
   }


### PR DESCRIPTION
…. +Ensured the indexInfo is updated in synchrony with the indices map.

The indicesMap is indexed by addresses and not public keys in other parts of the code. This caused the update function to never populate the index info correctly for local accounts. 
The call to allAccounts after the update of the map ensures that formatAccounts is called for the list of local accounts, which populates the right information.
This fix is necessary for the good behaviour of the [pull request in UI](https://github.com/polkawallet-io/ui/pull/1), but should be useful by itself.